### PR TITLE
fix #288976: stems too long on pitched/unpitched staves with scaled line distance

### DIFF
--- a/libmscore/chord.cpp
+++ b/libmscore/chord.cpp
@@ -1418,7 +1418,10 @@ qreal Chord::defaultStemLength()
             int n = tab1[hookIdx ? 1 : 0][up() ? 1 : 0][odd][_tremolo->lines()-1];
             stemLen += n * .5;
             }
-      return stemLen * _spatium * lineDistance;
+
+      if (tab)
+            stemLen *= lineDistance;
+      return stemLen * _spatium;
       }
 
 //---------------------------------------------------------


### PR DESCRIPTION
I had done q bit of work on staves with scale line distances some years ago, much of it seems still in place but some has been lost over time.  One thing that is lost is that stems on standard & percussion staves should not scale with line distance.  I had this working but it seems it was reverted in https://github.com/musescore/MuseScore/commit/337e885896d793f9893c2b8d454e1674ca9fb8b6#diff-428e0bb12d899d2d494b3cc99e75e22fL1334.  Simple enough to put it back.